### PR TITLE
Container bindings for Component Actions

### DIFF
--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -60,6 +60,17 @@ trait HandlesActions
         }
     }
 
+    protected function resolveActionParameters($method, $params)
+    {
+        return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use ($params) {
+            return rescue(function () use ($parameter) {
+                return app($parameter->getClass()->name);
+            }, function () use ($params) {
+                return array_shift($params);
+            }, false);
+        });
+    }
+
     protected function methodIsPublicAndNotDefinedOnBaseClass($methodName)
     {
         return collect((new \ReflectionClass($this))->getMethods(\ReflectionMethod::IS_PUBLIC))

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -55,7 +55,10 @@ trait HandlesActions
                 throw_unless(method_exists($this, $method), MissingComponentMethodReferencedByAction::class);
                 throw_unless($this->methodIsPublicAndNotDefinedOnBaseClass($method), NonPublicComponentMethodCall::class);
 
-                $this->{$method}(...$params);
+                $this->{$method}(
+                    ...$this->resolveActionParameters($method, $params)
+                );
+
                 break;
         }
     }

--- a/tests/DataBindingTest.php
+++ b/tests/DataBindingTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Livewire\Component;
 use Livewire\LivewireManager;
+use Illuminate\Routing\UrlGenerator;
 
 class DataBindingTest extends TestCase
 {
@@ -82,10 +83,22 @@ class DataBindingTest extends TestCase
         $this->assertEquals('something else', $component->instance->propertyWithHook);
         $this->assertContains('propertyWithHook', $component->dirtyInputs);
     }
+
+    /** @test */
+    function container_bindings()
+    {
+        $component = app(LivewireManager::class)->test(DataBindingStub::class);
+
+        $component->runAction('containerBindings', 'something');
+
+        $this->assertEquals(url('/'), $component->instance->foo);
+        $this->assertEquals('something', $component->instance->bar);
+    }
 }
 
 class DataBindingStub extends Component {
     public $foo;
+    public $bar;
     public $propertyWithHook;
     public $arrayProperty = ['foo', 'bar'];
 
@@ -107,6 +120,12 @@ class DataBindingStub extends Component {
     public function removeArrayPropertyOne()
     {
         unset($this->arrayProperty[1]);
+    }
+
+    public function containerBindings(UrlGenerator $generator, $bar)
+    {
+        $this->foo = $generator->to('/');
+        $this->bar = $bar;
     }
 
     public function render()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
**Needed :upside_down_face:**
**No, just wanted to put together a proof of concept**

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
**No**

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
**Yes**

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

**This will allow `Component` actions to type hint parameters that will be resolved out of the container while preserving the current affordance of passing values directly to the action.**

**Assume `Banana@peel()` is called like so:**
```php
peel(.75);
```

```php
use Animals\Monkey;
use Livewire\Component;

class Banana extends Component
{
    public function peel(Monkey $monkey, $percentage)
    {
        dd(get_class($monkey)); // \Animals\Monkey
        dd($percentage); // .75
    }
}
```
> **If this looks good and gets merged, I'll probably follow-up with some sort of `BindsMethodParameters` trait that both `Component` and `LivewireManager` can leverage so we can bind from the container in `Mount` as well.**

> **This implementation could potentially also be leveraged to rehydrate models, i.e. when parameter of an `Action` is typehinted to a `Model` and the parameter name matches a `public` property on the `Component`.**

> **Getting a little ahead here but worth acknowledging upfront that if the original state of the `Component's` `public` property that is a `Model` contained loaded relationships, rehydrating those relationships could be tricky**

5️⃣ Thanks for contributing! 🙌
