### PR TITLE
Support Laravel redirects in Components

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -15,16 +15,30 @@ use Livewire\Connection\HttpConnectionHandler;
 use Livewire\LivewireComponentsFinder;
 use Livewire\Macros\RouteMacros;
 use Livewire\Macros\RouterMacros;
+use Livewire\Routing\Redirector;
 
 class LivewireServiceProvider extends ServiceProvider
 {
     public function register()
     {
+        $this->interceptRedirect();
+
         $this->app->singleton('livewire', LivewireManager::class);
 
         $this->app->instance(LivewireComponentsFinder::class, new LivewireComponentsFinder(
             new Filesystem, app()->bootstrapPath('cache/livewire-components.php'), app_path('Http/Livewire')
         ));
+    }
+
+    protected function interceptRedirect()
+    {
+        $this->app->extend('redirect', function ($redirector) {
+            $component = collect(debug_backtrace())->pluck('object')->first(function ($object) {
+                return $object instanceof Component;
+            });
+
+            return $component ? resolve(Redirector::class)->component($component) : $redirector;
+        });
     }
 
     public function boot()

--- a/src/Routing/Redirector.php
+++ b/src/Routing/Redirector.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Livewire\Routing;
+
+use Livewire\Component;
+use Illuminate\Routing\Redirector as IlluminateRedirector;
+
+class Redirector extends IlluminateRedirector
+{
+    /**
+     * Set the redirect for Livewire to the given path.
+     *
+     * @param  string  $path
+     * @param  int     $status
+     * @param  array   $headers
+     * @param  bool|null    $secure
+     * @return self
+     */
+    public function to($path, $status = 302, $headers = [], $secure = null)
+    {
+        $this->component->redirect($this->generator->to($path, [], $secure));
+
+        return $this;
+    }
+
+    /**
+     * The Component resolving the Redirector.
+     *
+     * @param \Livewire\Component $component
+     * @return void
+     */
+    public function component(Component $component)
+    {
+        $this->component = $component;
+
+        return $this;
+    }
+}

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -4,17 +4,70 @@ namespace Tests;
 
 use Livewire\Component;
 use Livewire\LivewireManager;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Redirect;
 
 class RedirectTest extends TestCase
 {
     /** @test */
-    function validate_component_properties()
+    function validate_component_properties_from_local_redirect()
     {
         $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
 
         $component->runAction('triggerRedirect');
 
-        $this->assertEquals('/', $component->redirectTo);
+        $this->assertEquals('/local', $component->redirectTo);
+    }
+
+    /** @test */
+    function validate_component_properties_from_laravel_redirect_helper()
+    {
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelper');
+
+        $this->assertEquals(url('illuminate'), $component->redirectTo);
+    }
+
+    /** @test */
+    function validate_component_properties_from_laravel_redirect_facade_using_to()
+    {
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectFacadeUsingTo');
+
+        $this->assertEquals(url('illuminate'), $component->redirectTo);
+    }
+
+    /** @test */
+    function validate_component_properties_from_laravel_redirect_facade_using_route()
+    {
+        $this->registerNamedRoute();
+
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectFacadeUsingRoute');
+
+        $this->assertEquals(route('illuminate'), $component->redirectTo);
+    }
+
+    /** @test */
+    function validate_component_properties_from_laravel_redirect_helper_using_route()
+    {
+        $this->registerNamedRoute();
+
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelperUsingRoute');
+
+        $this->assertEquals(route('illuminate'), $component->redirectTo);
+    }
+
+    protected function registerNamedRoute()
+    {
+        Route::get('illuminate', function () {
+            return true;
+        })->name('illuminate');
     }
 }
 
@@ -22,7 +75,27 @@ class TriggersRedirectStub extends Component
 {
     public function triggerRedirect()
     {
-        $this->redirect('/');
+        return $this->redirect('/local');
+    }
+
+    public function triggerRedirectHelper()
+    {
+        return redirect('illuminate');
+    }
+
+    public function triggerRedirectFacadeUsingTo()
+    {
+        return Redirect::to('illuminate');
+    }
+
+    public function triggerRedirectFacadeUsingRoute()
+    {
+        return Redirect::route('illuminate');
+    }
+
+    public function triggerRedirectHelperUsingRoute()
+    {
+        return redirect()->route('illuminate');
     }
 
     public function render()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
**Needed :upside_down_face:**
**No, just wanted to put together a proof of concept**

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
**No**

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
**Yes**

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

**This will allow `Component` actions to use the core Laravel `Redirector` while preserving the current built-in redirect behavior**

```php
use Livewire\Component;
use Illuminate\Support\Facades\Redirect;

class Banana extends Component
{
    public $peeled = false;

    public function peel()
    {
        $this->peel = true;

        return redirect()->route('monkeys.index');
        // or
        return redirect('/monkeys');
        // or
        return Redirect::route('monkeys.index');
        // or
        return Redirect::to('/monkeys');
        // or
        return $this->redirect('/monkeys');
    }
}
```
> **A little unsure of the safety of this implementation, especially if additional third party packages extend `Redirector`. I _think_ it should be safe in that case.**

> **Also feels a little wonky directly extending `Redirector`, this was done because core `Redirect@route and redirect()` offload behind the scenes to `Redirector@to` so we get both `to()` and `route()` for the price of one overridden method.**

> **Just putting this up for feedback. :tada:**

5️⃣ Thanks for contributing! 🙌
